### PR TITLE
Exta fn supports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "github.com/OES/dss_rs"
 [dependencies]
 dss_rs_sys = { path = "dss_rs_sys" }
 libc = "0.2.126"
+raw-parts = "2.0.0"
 
 [features]
 default = ["unsafe"]

--- a/src/capacitors.rs
+++ b/src/capacitors.rs
@@ -4,6 +4,7 @@ use crate::dss_result::Result;
 use dss_rs_sys as dss_c;
 use std::{convert::TryInto, ffi::CString};
 use std::{ptr, slice};
+use raw_parts::RawParts;
 
 pub unsafe fn get_all_names(
     result_ptr: *mut *mut *mut ::std::os::raw::c_char,
@@ -102,9 +103,10 @@ pub unsafe fn get_states_gr() {
 }
 
 pub fn set_states(states: Vec<i32>) -> Result<()> {
+    let RawParts { ptr, length, .. } = RawParts::from_vec(states);
     unsafe {
-        let (value_ptr, value_count, _) = states.into_raw_parts();
-        dss_c::Capacitors_Set_States(value_ptr, value_count.try_into()?);
+        let ptr = ptr as *mut i32;
+        dss_c::Capacitors_Set_States(ptr, length.try_into()?);
     }
     Ok(())
 }

--- a/src/ckt_element.rs
+++ b/src/ckt_element.rs
@@ -53,6 +53,32 @@ pub fn get_voltages_mag_ang() -> Result<Vec<f64>> {
     }
 }
 
+pub fn get_currents_mag_ang() -> Result<Vec<f64>> {
+    unsafe {
+        let mut result_cnt = 0;
+        let mut result_ptr = ptr::null_mut();
+        dss_c::CktElement_Get_CurrentsMagAng(&mut result_ptr, &mut result_cnt);
+        if result_cnt == 0 || result_ptr == ptr::null_mut() {
+            return Err(DssError::NullCPtr);
+        }
+        let v = slice::from_raw_parts(result_ptr, result_cnt as usize).to_vec();
+        Ok(v)
+    }
+}
+
+pub fn get_total_powers() -> Result<Vec<f64>> {
+    unsafe {
+        let mut result_cnt = 0;
+        let mut result_ptr = ptr::null_mut();
+        dss_c::CktElement_Get_TotalPowers(&mut result_ptr, &mut result_cnt);
+        if result_cnt == 0 || result_ptr == ptr::null_mut() {
+            return Err(DssError::NullCPtr);
+        }
+        let v = slice::from_raw_parts(result_ptr, result_cnt as usize).to_vec();
+        Ok(v)
+    }
+}
+
 pub fn is_open(term: i32, phs: i32) -> u16 {
     unsafe {
         dss_c::CktElement_IsOpen(term, phs)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(vec_into_raw_parts)]
+//#![feature(vec_into_raw_parts)]
 /// A non-`unsafe` (re: safe) Rust API for [DSS_Extensions'][DSS_EXTENSIONS] `dss_capi`.
 ///
 /// [DSS_EXTENSIONS]:https://dss-extensions.org/

--- a/src/loads.rs
+++ b/src/loads.rs
@@ -1,4 +1,14 @@
 use dss_rs_sys as dss_c;
+use crate::dss_result::Result;
+use std::ffi::CString;
+
+pub fn set_name(value: &str) -> Result<()> {
+    unsafe {
+        let c_str = CString::new(value)?;
+        dss_c::PVSystems_Set_Name(c_str.into_raw());
+    }
+    Ok(())
+  }
 
 pub fn set_kw(value: f64) {
     unsafe {

--- a/src/reclosers.rs
+++ b/src/reclosers.rs
@@ -39,3 +39,11 @@ pub fn set_normal_state(value: i32) {
         dss_c::Reclosers_Set_NormalState(value);
     }
 }
+
+pub fn set_name(name: &str) -> Result<()> {
+    let name = std::ffi::CString::new(name).unwrap();
+    unsafe {
+        dss_c::Reclosers_Set_Name(name.as_ptr());
+    }
+    Ok(())
+}

--- a/src/relays.rs
+++ b/src/relays.rs
@@ -1,4 +1,5 @@
 extern crate dss_rs_sys;
+use crate::dss_result::Result;
 use dss_rs_sys as dss_c;
 
 pub fn close() {
@@ -11,4 +12,12 @@ pub fn open() {
     unsafe {
         dss_c::Relays_Open();
     }
+}
+
+pub fn set_name(name: &str) -> Result<()> {
+    let name = std::ffi::CString::new(name).unwrap();
+    unsafe {
+        dss_c::Relays_Set_Name(name.as_ptr());
+    }
+    Ok(())
 }


### PR DESCRIPTION
- Use raw-parts so no nightly needed
- Added fn to set_name for relays, reclosers, and loads
- Added fn to get current mag/ang, total_powers